### PR TITLE
✨ refactor: rename TLS secret file and update references

### DIFF
--- a/.github/workflows/renew-certificate.yml
+++ b/.github/workflows/renew-certificate.yml
@@ -49,38 +49,38 @@ jobs:
           TLS_CRT=$(cat $WORK_DIR/live/"$DOMAIN"/fullchain.pem | base64 -w 0)
           TLS_KEY=$(cat $WORK_DIR/live/"$DOMAIN"/privkey.pem | base64 -w 0)
 
-          cat <<EOF > wildcard-tls-secret.yaml
+          cat <<EOF > wildcard-tls.yaml
           apiVersion: v1
           data:
             tls.crt: $TLS_CRT
             tls.key: $TLS_KEY
           kind: Secret
           metadata:
-            name: wildcard-tls-secret
+            name: wildcard-tls
           type: Opaque
           EOF
 
-      - name: Upload Kubernetes secret as artifact
-        uses: actions/upload-artifact@v4.6.2
-        with:
-          name: wildcard-tls-secret
-          path: wildcard-tls-secret.yaml
+      # - name: Upload Kubernetes secret as artifact
+      #   uses: actions/upload-artifact@v4.6.2
+      #   with:
+      #     name: wildcard-tls
+      #     path: wildcard-tls.yaml
 
-      - name: Checkout stable branch
-        uses: actions/checkout@v2
-        with:
-          ref: stable
-          fetch-depth: 0
+      # - name: Checkout stable branch
+      #   uses: actions/checkout@v2
+      #   with:
+      #     ref: stable
+      #     fetch-depth: 0
 
-      - name: Update wildcard-tls-secret.yaml in stable branch
-        run: |
-          git config --global user.name 'GitHub Actions'
-          git config --global user.email 'actions@github.com'
-          git checkout stable
-          cp wildcard-tls-secret.yaml .github/workflows/
-          git add .github/workflows/wildcard-tls-secret.yaml
-          git commit -m 'Update wildcard-tls-secret.yaml'
-          git push origin stable
+      # - name: Update wildcard-tls.yaml in stable branch
+      #   run: |
+      #     git config --global user.name 'GitHub Actions'
+      #     git config --global user.email 'actions@github.com'
+      #     git checkout stable
+      #     cp wildcard-tls.yaml .github/workflows/
+      #     git add .github/workflows/wildcard-tls.yaml
+      #     git commit -m 'Update wildcard-tls.yaml'
+      #     git push origin stable
 
       - name: Create GitHub Release
         id: create_release
@@ -98,6 +98,6 @@ jobs:
         uses: actions/upload-release-asset@v1
         with:
           upload_url: ${{ steps.create_release.outputs.upload_url }}
-          asset_path: wildcard-tls-secret.yaml
-          asset_name: wildcard-tls-secret.yaml
+          asset_path: wildcard-tls.yaml
+          asset_name: wildcard-tls.yaml
           asset_content_type: application/x-yaml


### PR DESCRIPTION
Rename the TLS secret file from wildcard-tls-secret.yaml to 
wildcard-tls.yaml for clarity and consistency. all 
references in the workflow to reflect this change. Comment out 
unnecessary steps related to uploading and updating the secret 
in the stable branch to streamline the process.