### PR TITLE
✨ chore: update GitHub Actions workflow for Node.js

### DIFF
--- a/.github/workflows/renew-certificate.yml
+++ b/.github/workflows/renew-certificate.yml
@@ -60,6 +60,12 @@ jobs:
           type: Opaque
           EOF
 
+      - name: Install Node.js and @octokit/rest
+        uses: actions/setup-node@v2
+        with:
+          node-version: '16.x'
+      - run: npm install @octokit/rest
+
       - name: Get latest stable release
         id: get_latest_release
         uses: actions/github-script@v6


### PR DESCRIPTION
Adds Node.js setup and installs @octokit/rest in the 
renew-certificate workflow. This ensures the necessary 
dependencies are available for subsequent steps, 
improving the automation process.