### PR TITLE
✨ docs: clarify ArgoCD deployment note in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -132,6 +132,7 @@ curl -L "https://github.com/OpScaleHub/kind/releases/download/stable/wildcard-tl
 > [!NOTE]
 >
 > ArgoCD deployment is optional. You can skip this step if you don't need GitOps capabilities.
+>
 > If you choose to deploy ArgoCD, it will be installed with default configuration.
 
 ```bash


### PR DESCRIPTION
Add a note indicating that ArgoCD deployment is optional. This  improves clarity for users who may not require GitOps capabilities,  ensuring they understand they can skip this step if needed.