### PR TITLE
✨ fix: normalize repository name to lowercase in tags

### DIFF
--- a/.github/workflows/version-update.yml
+++ b/.github/workflows/version-update.yml
@@ -41,8 +41,8 @@ jobs:
           build-args: |
             KIND_VERSION=${{ needs.process-version.outputs.version }}
           tags: |
-            ghcr.io/${{ github.repository }}:v${{ needs.process-version.outputs.version }}
-            ghcr.io/${{ github.repository }}:latest
+            ghcr.io/${{ toLowerCase(github.repository) }}:v${{ needs.process-version.outputs.version }}
+            ghcr.io/${{ toLowerCase(github.repository) }}:latest
 
       - name: Generate cluster configuration
         run: |


### PR DESCRIPTION
Update the GitHub Actions workflow to ensure the repository name is  converted to lowercase when generating image tags. This change  prevents potential issues with case sensitivity in image references  and improves consistency across deployments.