### PR TITLE
✨ feat: add Cloudflare creds prep for cert renewal

### DIFF
--- a/.github/workflows/renew-certificate.yml
+++ b/.github/workflows/renew-certificate.yml
@@ -25,6 +25,22 @@ jobs:
           sudo apt-get update
           sudo apt-get install -y certbot python3-certbot-dns-cloudflare
 
+      - name: Prepare Cloudflare credentials
+        env:
+          API_TOKEN: ${{ secrets.API_TOKEN }}
+          DOMAIN: ${{ vars.DOMAIN }}
+        run: |
+          if [ -z "$API_TOKEN" ]; then
+            echo "ERROR: API_TOKEN secret is not set." >&2
+            exit 1
+          fi
+          if [ -z "$DOMAIN" ]; then
+            echo "ERROR: DOMAIN variable is not set." >&2
+            exit 1
+          fi
+          echo "dns_cloudflare_api_token = ${API_TOKEN}" > cloudflare.ini
+          chmod 600 cloudflare.ini
+
       - name: Renew certificate and create Kubernetes secret file
         env:
           DOMAIN: ${{ vars.DOMAIN }}
@@ -32,10 +48,11 @@ jobs:
           WORK_DIR="/tmp/letsencrypt"
           mkdir -p $WORK_DIR
           echo "The DOMAIN variable is set to $DOMAIN"
+          cp cloudflare.ini $WORK_DIR/cloudflare.ini
           certbot certonly \
             --domains "$DOMAIN,*.$DOMAIN" \
             --register-unsafely-without-email --agree-tos \
-            --dns-cloudflare --dns-cloudflare-credentials cloudflare.ini \
+            --dns-cloudflare --dns-cloudflare-credentials $WORK_DIR/cloudflare.ini \
             --server https://acme-v02.api.letsencrypt.org/directory  \
             --config-dir $WORK_DIR --work-dir $WORK_DIR --logs-dir $WORK_DIR
 


### PR DESCRIPTION
Add a step to prepare Cloudflare API credentials and ensure they
exist before running certbot in the renew-certificate workflow.

- Validate API_TOKEN secret and DOMAIN variable, failing early with a
  clear error message if missing.
- Write credentials to cloudflare.ini with strict permissions (600).
- Copy cloudflare.ini into the certbot work directory and update the
  certbot invocation to reference the file inside the work dir.

This prevents certbot failures due to missing credentials and keeps the
credentials scoped to the temporary work directory for safer handling.