### PR TITLE
✨ chore(release): remove existing wildcard asset before upload

### DIFF
--- a/.github/workflows/renew-certificate.yml
+++ b/.github/workflows/renew-certificate.yml
@@ -130,6 +130,21 @@ jobs:
                 prerelease: false
               });
             }
+            // Delete existing asset if present
+            const assets = await github.rest.repos.listReleaseAssets({
+              owner,
+              repo,
+              release_id: release.data.id
+            });
+            const existing = assets.data.find(a => a.name === 'wildcard-tls.yaml');
+            if (existing) {
+              await github.rest.repos.deleteReleaseAsset({
+                owner,
+                repo,
+                asset_id: existing.id
+              });
+              console.log('Deleted existing asset wildcard-tls.yaml');
+            }
             // Upload asset
             const assetPath = './wildcard-tls.yaml';
             if (!fs.existsSync(assetPath)) {


### PR DESCRIPTION
Delete any preexisting wildcard-tls.yaml release asset before
attempting to upload a fresh copy. This prevents upload failures or
duplicate assets when renewing the TLS certificate in the GitHub
Actions workflow, and ensures the workflow always publishes the
current artifact.

The change lists release assets, finds an asset named
wildcard-tls.yaml, deletes it if present, and logs the deletion. This
makes the renew-certificate workflow idempotent and more robust.