### PR TITLE
✨ ci: grant write permission to workflows for

### DIFF
--- a/.github/workflows/renew-certificate.yml
+++ b/.github/workflows/renew-certificate.yml
@@ -1,5 +1,8 @@
 name: Renew Certificate
 
+permissions:
+  contents: write
+
 on:
   # schedule:
   #   - cron: '0 7 * * 0'  # Runs weekly on Sundays at midnight

--- a/.github/workflows/renew-ingress-images.yml
+++ b/.github/workflows/renew-ingress-images.yml
@@ -1,6 +1,6 @@
 name: Renew Ingress Images
 permissions:
-  contents: read
+  contents: write
   pull-requests: write
 
 on:


### PR DESCRIPTION
Update two GitHub Actions workflows allow the runner to modify
repository contents during execution.

- Grant contents: write permission in .github/workflows/renew-ingress-
  images.yml so the action can update or commit files as needed.
- Add an explicit permissions block with contents: write to
  .github/workflows/renew-certificate.yml to enable the workflow to
 create or update artifacts or certificates in the repo.

These changes enable workflows that renew images and certificates to
push necessary updates back to the repository without permission
errors.