### PR TITLE
✨ feat: update yq image selection in workflow to match names

### DIFF
--- a/.github/workflows/renew-ingress-images.yml
+++ b/.github/workflows/renew-ingress-images.yml
@@ -37,8 +37,8 @@ jobs:
 
       - name: Update kustomization.yaml
         run: |
-          yq e -i ".images[0].newTag = \"${{ steps.check_images.outputs.controller_latest_digest }}\"" kind/ingress-nginx/kustomization.yaml
-          yq e -i ".images[1].newTag = \"${{ steps.check_images.outputs.certgen_latest_digest }}\"" kind/ingress-nginx/kustomization.yaml
+          yq e -i '(.images[] | select(.name == "registry.k8s.io/ingress-nginx/controller")).newTag = "${{ steps.check_images.outputs.controller_latest_digest }}"' kind/ingress-nginx/kustomization.yaml
+          yq e -i '(.images[] | select(.name == "registry.k8s.io/ingress-nginx/kube-webhook-certgen")).newTag = "${{ steps.check_images.outputs.certgen_latest_digest }}"' kind/ingress-nginx/kustomization.yaml
 
       - name: Create Pull Request
         uses: peter-evans/create-pull-request@v4


### PR DESCRIPTION
Update the renew-ingress-images workflow to set image tags by
selecting entries by their full image name instead of relying on
fixed array indices.

- Replace index-based updates with yq selects for the controller and
  kube-webhook-certgen image entries in kind/ingress-nginx/kustomization.yaml.
- This makes the workflow resilient to reordering or adding images in the
  kustomization file and prevents accidentally updating the wrong image
  when the images array changes.