### PR TITLE
✨ feat: make ingress image lookup and update robust

### DIFF
--- a/.github/workflows/renew-ingress-images.yml
+++ b/.github/workflows/renew-ingress-images.yml
@@ -23,13 +23,13 @@ jobs:
         id: check_images
         run: |
           # Controller Image
-          CONTROLLER_IMAGE_NAME=$(yq e '.images[0].name' kind/ingress-nginx/kustomization.yaml)
-          CONTROLLER_CURRENT_TAG=$(yq e '.images[0].newTag' kind/ingress-nginx/kustomization.yaml)
+          CONTROLLER_IMAGE_NAME=$(yq e '(.images[] | select(.name == "registry.k8s.io/ingress-nginx/controller")).newName' kind/ingress-nginx/kustomization.yaml)
+          CONTROLLER_CURRENT_TAG=$(yq e '(.images[] | select(.name == "registry.k8s.io/ingress-nginx/controller")).newTag' kind/ingress-nginx/kustomization.yaml)
           CONTROLLER_LATEST_DIGEST=$(skopeo inspect docker://${CONTROLLER_IMAGE_NAME}:${CONTROLLER_CURRENT_TAG} | jq -r '.Digest')
           
           # Certgen Image
-          CERTGEN_IMAGE_NAME=$(yq e '.images[1].name' kind/ingress-nginx/kustomization.yaml)
-          CERTGEN_CURRENT_TAG=$(yq e '.images[1].newTag' kind/ingress-nginx/kustomization.yaml)
+          CERTGEN_IMAGE_NAME=$(yq e '(.images[] | select(.name == "registry.k8s.io/ingress-nginx/kube-webhook-certgen")).newName' kind/ingress-nginx/kustomization.yaml)
+          CERTGEN_CURRENT_TAG=$(yq e '(.images[] | select(.name == "registry.k8s.io/ingress-nginx/kube-webhook-certgen")).newTag' kind/ingress-nginx/kustomization.yaml)
           CERTGEN_LATEST_DIGEST=$(skopeo inspect docker://${CERTGEN_IMAGE_NAME}:${CERTGEN_CURRENT_TAG} | jq -r '.Digest')
 
           echo "::set-output name=controller_latest_digest::$CONTROLLER_LATEST_DIGEST"
@@ -37,8 +37,8 @@ jobs:
 
       - name: Update kustomization.yaml
         run: |
-          yq e -i '(.images[] | select(.name == "registry.k8s.io/ingress-nginx/controller")).newTag = "${{ steps.check_images.outputs.controller_latest_digest }}"' kind/ingress-nginx/kustomization.yaml
-          yq e -i '(.images[] | select(.name == "registry.k8s.io/ingress-nginx/kube-webhook-certgen")).newTag = "${{ steps.check_images.outputs.certgen_latest_digest }}"' kind/ingress-nginx/kustomization.yaml
+          yq e -i '(.images[] | select(.name == "registry.k8s.io/ingress-nginx/controller")).newTag |= "${{ steps.check_images.outputs.controller_latest_digest }}"' kind/ingress-nginx/kustomization.yaml
+          yq e -i '(.images[] | select(.name == "registry.k8s.io/ingress-nginx/kube-webhook-certgen")).newTag |= "${{ steps.check_images.outputs.certgen_latest_digest }}"' kind/ingress-nginx/kustomization.yaml
 
       - name: Create Pull Request
         uses: peter-evans/create-pull-request@v4


### PR DESCRIPTION
Use yq to find images by name instead of relying on
fixed array indices, and switch to update operator '|=' when writing
newTag values. This prevents incorrect image selection and keeps the
kustomization updates stable if image ordering changes.

- Read newName/newTag for controller and certgen by selecting the
  matching .name entries.
- Use '|=' in yq edits to safely assign the output digest values.

This improves reliability of the renew-ingress-images workflow when
kustomization.yaml entries are reordered or adjusted.