### PR TITLE
✨ chore: update GitHub Actions outputs to use GITHUB_OUTPUT

### DIFF
--- a/.github/workflows/renew-ingress-images.yml
+++ b/.github/workflows/renew-ingress-images.yml
@@ -32,8 +32,8 @@ jobs:
           CERTGEN_CURRENT_TAG=$(yq e '(.images[] | select(.name == "registry.k8s.io/ingress-nginx/kube-webhook-certgen")).newTag' kind/ingress-nginx/kustomization.yaml)
           CERTGEN_LATEST_DIGEST=$(skopeo inspect docker://${CERTGEN_IMAGE_NAME}:${CERTGEN_CURRENT_TAG} | jq -r '.Digest')
 
-          echo "::set-output name=controller_latest_digest::$CONTROLLER_LATEST_DIGEST"
-          echo "::set-output name=certgen_latest_digest::$CERTGEN_LATEST_DIGEST"
+          echo "controller_latest_digest=$CONTROLLER_LATEST_DIGEST" >> $GITHUB_OUTPUT
+          echo "certgen_latest_digest=$CERTGEN_LATEST_DIGEST" >> $GITHUB_OUTPUT
 
       - name: Update kustomization.yaml
         run: |


### PR DESCRIPTION
Switch the workflow step that captures image digests to use the
GITHUB_OUTPUT file instead of the deprecated ::set-output command.

- Replace deprecated echo "::set-output name=...::value" with
  echo "name=value" >> $GITHUB_OUTPUT to avoid action warnings and
  ensure future compatibility with GitHub Actions.
- Update both controller_latest_digest and certgen_latest_digest
  assignments in renew-ingress-images.yml.

This prevents failures or deprecation warnings when running the CI
workflow and aligns with GitHub Actions current recommended practice.