### PR TITLE
✨ feat: add debugging output to ingress image renewal job

### DIFF
--- a/.github/workflows/renew-ingress-images.yml
+++ b/.github/workflows/renew-ingress-images.yml
@@ -22,15 +22,22 @@ jobs:
       - name: Check for new image digests
         id: check_images
         run: |
+          set -ex
           # Controller Image
           CONTROLLER_IMAGE_NAME=$(yq e '(.images[] | select(.name == "registry.k8s.io/ingress-nginx/controller")).newName' kind/ingress-nginx/kustomization.yaml)
           CONTROLLER_CURRENT_TAG=$(yq e '(.images[] | select(.name == "registry.k8s.io/ingress-nginx/controller")).newTag' kind/ingress-nginx/kustomization.yaml)
+          echo "CONTROLLER_IMAGE_NAME: ${CONTROLLER_IMAGE_NAME}"
+          echo "CONTROLLER_CURRENT_TAG: ${CONTROLLER_CURRENT_TAG}"
           CONTROLLER_LATEST_DIGEST=$(skopeo inspect docker://${CONTROLLER_IMAGE_NAME}:${CONTROLLER_CURRENT_TAG} | jq -r '.Digest')
+          echo "CONTROLLER_LATEST_DIGEST: ${CONTROLLER_LATEST_DIGEST}"
           
           # Certgen Image
           CERTGEN_IMAGE_NAME=$(yq e '(.images[] | select(.name == "registry.k8s.io/ingress-nginx/kube-webhook-certgen")).newName' kind/ingress-nginx/kustomization.yaml)
           CERTGEN_CURRENT_TAG=$(yq e '(.images[] | select(.name == "registry.k8s.io/ingress-nginx/kube-webhook-certgen")).newTag' kind/ingress-nginx/kustomization.yaml)
+          echo "CERTGEN_IMAGE_NAME: ${CERTGEN_IMAGE_NAME}"
+          echo "CERTGEN_CURRENT_TAG: ${CERTGEN_CURRENT_TAG}"
           CERTGEN_LATEST_DIGEST=$(skopeo inspect docker://${CERTGEN_IMAGE_NAME}:${CERTGEN_CURRENT_TAG} | jq -r '.Digest')
+          echo "CERTGEN_LATEST_DIGEST: ${CERTGEN_LATEST_DIGEST}"
 
           echo "controller_latest_digest=$CONTROLLER_LATEST_DIGEST" >> $GITHUB_OUTPUT
           echo "certgen_latest_digest=$CERTGEN_LATEST_DIGEST" >> $GITHUB_OUTPUT


### PR DESCRIPTION
Add set -ex and echo debug statements in the GitHub Actions job that
checks image digests for ingress-nginx. Log the image names, current
tags and fetched digests for the controller and kube-webhook
certgen images, and print the latest digest values to help troubleshoot
skopeo/jq inspection failures and CI flakiness.

This improves observability of the renew-ingress-images workflow and
makes it easier to diagnose mismatches between expected tags and
retrieved digests during automated image renewal.