### PR TITLE
✨ chore(workflows): add packages permission and ghcr login step

### DIFF
--- a/.github/workflows/renew-ingress-images.yml
+++ b/.github/workflows/renew-ingress-images.yml
@@ -2,6 +2,7 @@ name: Renew Ingress Images
 permissions:
   contents: write
   pull-requests: write
+  packages: read
 
 on:
   schedule:
@@ -18,6 +19,9 @@ jobs:
 
       - name: Set up yq
         uses: mikefarah/yq@v4.27.5
+
+      - name: Log in to GitHub Container Registry
+        run: echo "${{ secrets.GITHUB_TOKEN }}" | skopeo login ghcr.io -u "${{ github.actor }}" --password-stdin
 
       - name: Check for new image digests
         id: check_images


### PR DESCRIPTION
Add packages: read permission to the renew-ingress-images workflow and
insert a GitHub Container Registry login step using skopeo.

These changes ensure the scheduled job can read package metadata and
authenticate to ghcr.io when checking image digests, preventing failures
when accessing container registries and making image renewals reliable.