### PR TITLE
✨ chore: packages permission to write workflow

### DIFF
--- a/.github/workflows/renew-ingress-images.yml
+++ b/.github/workflows/renew-ingress-images.yml
@@ -2,7 +2,7 @@ name: Renew Ingress Images
 permissions:
   contents: write
   pull-requests: write
-  packages: read
+  packages: write
 
 on:
   schedule:


### PR DESCRIPTION
Update renewress-images workflow to the packages
permission (instead of read). This allows the job to
publish or update package artifacts as part of its run,
supporting automated image and package renewal tasks that
need to push changes. Adjusting the permission prevents
permission-denied failures during publishing steps.